### PR TITLE
remove default from OptionalCharField (not used warnings)

### DIFF
--- a/verzekeringen_api/apps/insurances/models/insurance_claim.py
+++ b/verzekeringen_api/apps/insurances/models/insurance_claim.py
@@ -53,31 +53,31 @@ class InsuranceClaim(AuditedBaseModel):
     damage_type = OptionalCharField(max_length=128)
 
     # Was there someone else involved in the accident ?
-    involved_party = OptionalCharField(max_length=30, blank=True, null=True, default=None)
+    involved_party = OptionalCharField(max_length=30, blank=True, null=True)
     involved_party_name = OptionalCharField(max_length=1024)
     involved_party_description = OptionalCharField(max_length=1024)
     involved_party_birthdate = OptionalDateField()
 
     # Was the accident reported by an official instance ?
-    official_report = OptionalCharField(max_length=30, blank=True, null=True, default=None)
+    official_report = OptionalCharField(max_length=30, blank=True, null=True)
 
     official_report_description = OptionalCharField(max_length=1024)
     pv_number = OptionalCharField(max_length=30)
 
     # Was there a witness to the accident ?
-    witness = OptionalCharField(max_length=30, blank=True, null=True, default=None)
+    witness = OptionalCharField(max_length=30, blank=True, null=True)
     witness_name = OptionalCharField(max_length=128)
     witness_description = OptionalCharField(max_length=1024)
 
     # Was someone keeping watch over the scouts group while the accident happened ?
-    leadership = OptionalCharField(max_length=30, blank=True, null=True, default=None)
+    leadership = OptionalCharField(max_length=30, blank=True, null=True)
     leadership_description = OptionalCharField(max_length=1024)
 
     # Administrative personel can add case notes and insurance company case number
     note = OptionalCharField(max_length=1024)
     case_number = OptionalCharField(max_length=30)
 
-    attachment_name = OptionalCharField(max_length=1024, blank=True, null=True, default=None)
+    attachment_name = OptionalCharField(max_length=1024, blank=True, null=True)
     # Full scouts group details
     _group: AbstractScoutsGroup = None
     # Full groupadmin member data for the declarant

--- a/verzekeringen_api/scouts_auth/inuits/models/inuits_address.py
+++ b/verzekeringen_api/scouts_auth/inuits/models/inuits_address.py
@@ -5,7 +5,7 @@ from scouts_auth.inuits.models.fields import OptionalCharField, OptionalIntegerF
 class InuitsAddress(AbstractNonModel):
     street = OptionalCharField(max_length=100)
     number = OptionalCharField(max_length=5)
-    letter_box = OptionalCharField(max_length=5, default=None, blank=True, null=True)
+    letter_box = OptionalCharField(max_length=5, blank=True, null=True)
     postal_code = OptionalIntegerField()
     city = OptionalCharField(max_length=40)
     # country = models.ForeignKey(InuitsCountry, on_delete=models.CASCADE, null=True, related_name="address")

--- a/verzekeringen_api/scouts_insurances/insurances/models/vehicle_related_insurance.py
+++ b/verzekeringen_api/scouts_insurances/insurances/models/vehicle_related_insurance.py
@@ -26,7 +26,7 @@ class VehicleRelatedInsurance(models.Model):
     _vehicle_brand = OptionalCharField(db_column="automerk", max_length=15)
     _vehicle_license_plate = OptionalCharField(db_column="autokenteken", max_length=10)
     _vehicle_construction_year = OptionalIntegerField(db_column="autobouwjaar", validators=[MinValueValidator(1900)])
-    _vehicle_chassis_number = OptionalCharField(db_column="autochassis", max_length=20, null=True, default=None, blank=True)
+    _vehicle_chassis_number = OptionalCharField(db_column="autochassis", max_length=20, null=True, blank=True)
 
     class Meta:
         abstract = True
@@ -34,15 +34,15 @@ class VehicleRelatedInsurance(models.Model):
     def clean(self):
         super().clean()
         if not (
-                self._vehicle_type
-                and self._vehicle_brand
-                and self._vehicle_license_plate
-                and self._vehicle_construction_year
+            self._vehicle_type
+            and self._vehicle_brand
+            and self._vehicle_license_plate
+            and self._vehicle_construction_year
         ) and not (
-                not self._vehicle_type
-                and not self._vehicle_brand
-                and not self._vehicle_license_plate
-                and not self._vehicle_construction_year
+            not self._vehicle_type
+            and not self._vehicle_brand
+            and not self._vehicle_license_plate
+            and not self._vehicle_construction_year
         ):
             raise serializers.ValidationError("If one vehicle field given all vehicle fields need to be given")
 


### PR DESCRIPTION
- remove defaults from optional charfield


these default is not used, but trigger a warning, polluting the error-output

https://github.com/ScoutsGidsenVL/verzekeringen-backend/blob/staging/verzekeringen_api/scouts_auth/inuits/models/fields/django_shorthand_model_fields.py

<img width="761" alt="image" src="https://github.com/ScoutsGidsenVL/verzekeringen-backend/assets/469509/ba7b4204-e1e7-4f6d-b3e5-2f63126b29ee">
