### PR TITLE
Fix information exposure

### DIFF
--- a/verzekeringen_api/scouts_auth/auth/views/oidc_auth_code_view.py
+++ b/verzekeringen_api/scouts_auth/auth/views/oidc_auth_code_view.py
@@ -36,7 +36,8 @@ class OIDCAuthCodeView(views.APIView):
         except HTTPError as exc:
             logger.error(f"Failed to refresh tokens: {exc}")
             # raise TokenRequestException("Failed to refresh tokens.")
-            raise TokenRequestException(exc)
+            # this custom error takes an exception as input-argument
+            raise TokenRequestException(exc) from exc
 
         output_serializer = TokenSerializer(tokens)
 

--- a/verzekeringen_api/scouts_auth/auth/views/oidc_refresh_view.py
+++ b/verzekeringen_api/scouts_auth/auth/views/oidc_refresh_view.py
@@ -29,11 +29,14 @@ class OIDCRefreshView(views.APIView):
 
         data = serializer.validated_data
         try:
-            tokens = self.service.get_tokens_by_refresh_token(user=request.user, refresh_token=data.get("refreshToken"))
+            tokens = self.service.get_tokens_by_refresh_token(
+                user=request.user, refresh_token=data.get("refreshToken")
+            )
         except HTTPError as exc:
             logger.error(f"Failed to refresh tokens: {exc}")
             # raise TokenRequestException("Failed to refresh tokens.")
-            raise TokenRequestException(exc)
+            # this custom error takes an exception as input-argument
+            raise TokenRequestException(exc) from exc
 
         output_serializer = TokenSerializer(tokens)
 

--- a/verzekeringen_api/scouts_insurances/insurances/services/insurance_mail_service.py
+++ b/verzekeringen_api/scouts_insurances/insurances/services/insurance_mail_service.py
@@ -193,7 +193,9 @@ class InsuranceMailService(EmailService):
             for participant in insurance.participants.all():
                 participants.append(participant.full_name())
             vehicle = (
-                f"<li>Voertuig: {insurance.vehicle_with_simple_trailer_to_str_mail()}</li>" if insurance.vehicle else ""
+                f"<li>Voertuig: {insurance.vehicle_with_simple_trailer_to_str_mail()}</li>"
+                if insurance.vehicle
+                else ""
             )
             return (
                 f"<li>Periode: {insurance.start_date.strftime('%d %b %Y')} - {insurance.end_date.strftime('%d %b %Y')}</li>"
@@ -247,7 +249,6 @@ class InsuranceMailService(EmailService):
         html_body = " ".join(html_body.splitlines())
         # Combineer opeenvolgende spaties
         html_body = re.sub("  +", " ", html_body)
-        logger.info(html_body)
 
         if not reply_to:
             reply_to = self.from_email


### PR DESCRIPTION
- remove logging of full email-body
   fixes https://github.com/ScoutsGidsenVL/verzekeringen-backend/security/code-scanning/5

- dismiss alert https://github.com/ScoutsGidsenVL/verzekeringen-backend/security/code-scanning/3

- add raise from when raising from an expeption.
   However we can not fixthecurrent issue, 
   because the custom Exception takes another exception as input-argument, triggering this alert.
   dismiss https://github.com/ScoutsGidsenVL/verzekeringen-backend/security/code-scanning/1
   dismiss  https://github.com/ScoutsGidsenVL/verzekeringen-backend/security/code-scanning/2

