### PR TITLE
T6362 Hide vvksm_comment for non-admin users.

### DIFF
--- a/verzekeringen_api/apps/insurances/views/base_insurance_viewset.py
+++ b/verzekeringen_api/apps/insurances/views/base_insurance_viewset.py
@@ -11,14 +11,18 @@ from apps.insurances.serializers import (
     InuitsTemporaryInsuranceSerializer,
     InuitsTravelAssistanceInsuranceSerializer,
     InuitsTemporaryVehicleInsuranceSerializer,
-    InuitsEquipmentInsuranceSerializer, InuitsEventInsuranceSerializer, InuitsActivityInsuranceSerializer,
+    InuitsEquipmentInsuranceSerializer,
+    InuitsEventInsuranceSerializer,
+    InuitsActivityInsuranceSerializer,
 )
 
 from scouts_insurances.insurances.models import BaseInsurance
 from scouts_insurances.insurances.serializers import (
     BaseInsuranceSerializer,
     ActivityInsuranceSerializer,
-    EventInsuranceSerializer, TemporaryInsuranceSerializer, EquipmentInsuranceSerializer,
+    EventInsuranceSerializer,
+    TemporaryInsuranceSerializer,
+    EquipmentInsuranceSerializer,
 )
 
 
@@ -49,9 +53,7 @@ class BaseInsuranceViewSet(viewsets.GenericViewSet):
             or insurance.type.is_equipment_insurance()
         ):
             if insurance.type.is_temporary_insurance():
-                serializer = TemporaryInsuranceSerializer(
-                    insurance.temporary_child, context={"request": request}
-                )
+                serializer = TemporaryInsuranceSerializer(insurance.temporary_child, context={"request": request})
             elif (
                 insurance.type.is_travel_assistance_without_vehicle_insurance()
                 or insurance.type.is_travel_assistance_with_vehicle_insurance()
@@ -64,9 +66,7 @@ class BaseInsuranceViewSet(viewsets.GenericViewSet):
                     insurance.temporary_vehicle_child, context={"request": request}
                 )
             elif insurance.type.is_equipment_insurance():
-                serializer = EquipmentInsuranceSerializer(
-                    insurance.equipment_child, context={"request": request}
-                )
+                serializer = EquipmentInsuranceSerializer(insurance.equipment_child, context={"request": request})
         elif insurance.type.is_activity_insurance():
             serializer = InuitsActivityInsuranceSerializer(insurance.activity_child, context={"request": request})
         elif insurance.type.is_event_insurance():
@@ -87,12 +87,14 @@ class BaseInsuranceViewSet(viewsets.GenericViewSet):
         insurances = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(insurances)
 
-        # for insurance in insurances:
-        #     logger.debug(insurance)
+        # Only show the vvksm_comment field to administrators (T6362).
+        exclude_fields = []
+        if not request.user.has_role_administrator():
+            exclude_fields = ["vvksm_comment"]
 
         if page is not None:
-            serializer = BaseInsuranceSerializer(page, many=True)
+            serializer = BaseInsuranceSerializer(page, many=True, exclude_fields=exclude_fields)
             return self.get_paginated_response(serializer.data)
         else:
-            serializer = BaseInsuranceSerializer(insurances, many=True)
+            serializer = BaseInsuranceSerializer(insurances, many=True, exclude_fields=exclude_fields)
             return Response(serializer.data)

--- a/verzekeringen_api/scouts_insurances/insurances/serializers/base_insurance_serializer.py
+++ b/verzekeringen_api/scouts_insurances/insurances/serializers/base_insurance_serializer.py
@@ -63,7 +63,12 @@ class BaseInsuranceSerializer(serializers.ModelSerializer):
         ]
 
     def __init__(self, *args, **kwargs):
+        """Add possibility to exclude fields from serializer."""
+        exclude_fields = kwargs.pop("exclude_fields", None)
         super().__init__(*args, **kwargs)
+        if exclude_fields:
+            for field in exclude_fields:
+                self.fields.pop(field, None)
 
     def to_internal_value(self, data: dict) -> dict:
         total_cost = data.pop("total_cost", None)


### PR DESCRIPTION
By implementing an exclude_fields option to the insurance serializer,
it is now possible to hide fields for non admin users for the insurance
serializer only. This is only used for the endpoint /insurances/!

**Tested via**
1. Go to " previously requested insurances" as admin user
2. Check the data of the response
3. -> Can still see the field

4. Go to the same page as non admin user (or in my case, comment the if so it is also used for admins)
5. -> Can no longer see the field in the output of the response
